### PR TITLE
Extend profile handling

### DIFF
--- a/conformity/conformity_profile_validation.go
+++ b/conformity/conformity_profile_validation.go
@@ -21,6 +21,17 @@ func CustomizeDiffValidateProfileValue(_ context.Context, diff *schema.ResourceD
 			for esi, es := range ess {
 				esItem := es.(map[string]interface{})
 				value := esItem["value"].(string)
+
+				// only provide either of value, values, or valuesArr
+				clauseA := value != "" && esItem["values"] != nil && len(esItem["values"].(*schema.Set).List()) > 0
+				clauseB := value != "" && esItem["values_array"] != nil && len(esItem["values_array"].(*schema.Set).List()) > 0
+				clauseC := esItem["values"] != nil && esItem["values_array"] != nil && len(esItem["values"].(*schema.Set).List()) > 0 && len(esItem["values_array"].(*schema.Set).List()) > 0
+				if clauseA || clauseB || clauseC {
+					return fmt.Errorf(
+						"only provide either of value, values, or values_arr for the extra_settings %s", esItem["name"].(string),
+					)
+				}
+
 				log.Printf("[DEBUG] customize type: %v", esItem["type"].(string))
 
 				if esItem["type"].(string) == "single-number-value" || esItem["type"].(string) == "ttl" {

--- a/conformity/resource_conformity_profile.go
+++ b/conformity/resource_conformity_profile.go
@@ -421,7 +421,8 @@ func flattenProfileExtraSettings(extra []cloudconformity.IncludedExtraSettings) 
 		if extraSettings.Type == "single-string-value" ||
 			extraSettings.Type == "single-number-value" ||
 			extraSettings.Type == "ttl" ||
-			extraSettings.Type == "single-value-regex" {
+			extraSettings.Type == "single-value-regex" ||
+			extraSettings.Type == "choice-single-value" {
 			es["value"] = fmt.Sprintf("%s", extraSettings.Value)
 		} else if extraSettings.Type == "regions" {
 			es["values_array"] = extraSettings.Values

--- a/pkg/cloudconformity/get_profile_test.go
+++ b/pkg/cloudconformity/get_profile_test.go
@@ -20,6 +20,37 @@ func TestGetProfileSuccess(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, profileSettings.Data.ID, expectedProfileID)
 }
+func TestGetProfileGenericValuesSuccess(t *testing.T) {
+	// prepare the test
+	expectedProfileID := "d9yHTrzP0"
+	response := testGetProfileSuccessResponseGenericProfileValues
+	client, ts := createHttpTestClient(t, http.StatusOK, response)
+	defer ts.Close()
+
+	// run the code
+	profileSettings, err := client.GetProfile("some-id")
+	// check the results
+	assert.Nil(t, err)
+	assert.Equal(t, profileSettings.Data.ID, expectedProfileID)
+	for _, ele := range profileSettings.Included {
+		assert.NotNil(t, ele.Attributes.ExtraSettings)
+		assert.Greater(t, len(ele.Attributes.ExtraSettings), 0)
+		for _, extraEle := range ele.Attributes.ExtraSettings {
+			assert.Greater(t, len(extraEle.Values), 0)
+			for _, genericProfileElement := range extraEle.Values {
+				values, isStruct := genericProfileElement.(map[string]interface{})
+				if isStruct {
+					assert.NotNil(t, genericProfileElement)
+					assert.NotEmpty(t, values["value"])
+					assert.True(t, values["enabled"].(bool))
+					assert.Equal(t, values["label"], "_label")
+				} else {
+					assert.NotEmpty(t, genericProfileElement)
+				}
+			}
+		}
+	}
+}
 func TestGetProfileFail(t *testing.T) {
 	// prepare the test
 	client, ts := createHttpTestClient(t, http.StatusForbidden, errResponse)
@@ -32,3 +63,91 @@ func TestGetProfileFail(t *testing.T) {
 	assert.EqualError(t, err, errResponse)
 	assert.Nil(t, profileSettings)
 }
+
+/*
+Allows testing two cases:
+  1- when the value is int/float
+  2- when the value is []string
+Refer to bug reported in:
+https://github.com/trendmicro/terraform-provider-conformity/issues/32
+*/
+var testGetProfileSuccessResponseGenericProfileValues = `
+{
+  "data": {
+    "type": "profiles",
+    "id": "d9yHTrzP0",
+    "attributes": {
+      "name": "hemen test 1",
+      "description": "hemen test 1"
+    },
+    "relationships": {
+      "ruleSettings": {
+        "data": [
+          {
+            "type": "rules",
+            "id": "EC2-055"
+          },
+          {
+            "type": "rules",
+            "id": "RTM-008"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "type": "rules",
+      "id": "EC2-055",
+      "attributes": {
+        "enabled": true,
+        "extraSettings": [
+          {
+            "name": "commonlyUsedPorts",
+            "type": "multiple-number-values",
+            "values": [
+              { 
+				"label": "_label",
+				"enabled": true,
+                "value": 80
+              },
+              {
+				"label": "_label",
+				"enabled": true,
+                "value": 443
+              },
+              {
+				"label": "_label",
+				"enabled": true,
+                "value": 12.34
+              }
+            ]
+          }
+        ],
+        "riskLevel": "HIGH",
+        "provider": "aws"
+      }
+    },
+    {
+      "type": "rules",
+      "id": "RTM-008",
+      "attributes": {
+        "enabled": true,
+        "extraSettings": [
+          {
+            "name": "authorisedRegions",
+            "regions": true,
+            "type": "regions",
+            "values": [
+              "af-south-1",
+              "ap-east-1",
+              "ap-northeast-1",
+              "ap-northeast-2"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}
+`

--- a/pkg/cloudconformity/models.go
+++ b/pkg/cloudconformity/models.go
@@ -17,13 +17,13 @@ type AccountKeys struct {
 	ExternalId string `json:"externalId"`
 }
 type accountAccess struct {
-	Keys              *AccountKeys `json:"keys,omitempty"`
-	Type              string       `json:"type,omitempty"`
-	SubscriptionId    string       `json:"subscriptionId,omitempty"`
-	ActiveDirectoryId string       `json:"activeDirectoryId,omitempty"`
-	ProjectId		  string       `json:"projectId,omitempty"`
-	ProjectName 	  string       `json:"projectName,omitempty"`
-	ServiceAccountUniqueId string  `json:"serviceAccountUniqueId,omitempty"`
+	Keys                   *AccountKeys `json:"keys,omitempty"`
+	Type                   string       `json:"type,omitempty"`
+	SubscriptionId         string       `json:"subscriptionId,omitempty"`
+	ActiveDirectoryId      string       `json:"activeDirectoryId,omitempty"`
+	ProjectId              string       `json:"projectId,omitempty"`
+	ProjectName            string       `json:"projectName,omitempty"`
+	ServiceAccountUniqueId string       `json:"serviceAccountUniqueId,omitempty"`
 }
 type AccountConfiguration struct {
 	ExternalId string `json:"externalId,omitempty"`
@@ -165,13 +165,13 @@ type AccountSettings struct {
 }
 
 type accountAttributes struct {
-	Name          string                `json:"name"`
-	Environment   string                `json:"environment"`
-	ManagedGroupId  string                `json:"managed-group-id"`
-	Tags          []string              `json:"tags"`
+	Name           string   `json:"name"`
+	Environment    string   `json:"environment"`
+	ManagedGroupId string   `json:"managed-group-id"`
+	Tags           []string `json:"tags"`
 	//Access        accountAccess         `json:"access,omitempty"`
 	Configuration *AccountConfiguration `json:"configuration,omitempty"`
-	CloudType      string                `json:"cloud-type,omitempty"`
+	CloudType     string                `json:"cloud-type,omitempty"`
 	CloudData     *CloudData            `json:"cloud-data,omitempty"`
 	Settings      *AccountSettings      `json:"settings,omitempty"`
 }
@@ -182,7 +182,7 @@ type createAccountAttributes struct {
 	Tags          []string              `json:"tags"`
 	Access        accountAccess         `json:"access,omitempty"`
 	Configuration *AccountConfiguration `json:"configuration,omitempty"`
-	CloudType      string                `json:"cloud-type,omitempty"`
+	CloudType     string                `json:"cloud-type,omitempty"`
 	CloudData     *CloudData            `json:"cloud-data,omitempty"`
 	Settings      *AccountSettings      `json:"settings,omitempty"`
 }
@@ -193,7 +193,7 @@ type accountData struct {
 }
 
 type createAccountData struct {
-	Type       string            `json:"type,omitempty"`
+	Type       string                  `json:"type,omitempty"`
 	Attributes createAccountAttributes `json:"attributes"`
 }
 
@@ -429,19 +429,21 @@ type IncludedExceptions struct {
 	Resources  []string `json:"resources,omitempty"`
 	Tags       []string `json:"tags,omitempty"`
 }
+
 type ProfileValues struct {
-	Label   string `json:"label,omitempty"`
-	Value   string `json:"value,omitempty"`
-	Enabled bool   `json:"enabled,omitempty"`
+	Label   string      `json:"label,omitempty"`
+	Value   interface{} `json:"value,omitempty"`
+	Enabled bool        `json:"enabled,omitempty"`
 }
+
 type IncludedExtraSettings struct {
-	Countries bool             `json:"countries,omitempty"`
-	Multiple  bool             `json:"multiple,omitempty"`
-	Name      string           `json:"name,omitempty"`
-	Regions   bool             `json:"regions,omitempty"`
-	Type      string           `json:"type,omitempty"`
-	Value     interface{}      `json:"value,omitempty"`
-	Values    []*ProfileValues `json:"values,omitempty"`
+	Countries bool          `json:"countries,omitempty"`
+	Multiple  bool          `json:"multiple,omitempty"`
+	Name      string        `json:"name,omitempty"`
+	Regions   bool          `json:"regions,omitempty"`
+	Type      string        `json:"type,omitempty"`
+	Value     interface{}   `json:"value,omitempty"`
+	Values    []interface{} `json:"values,omitempty"`
 }
 type IncludedAttributes struct {
 	Enabled       bool                    `json:"enabled"`
@@ -487,33 +489,33 @@ type ApplyProfileResponse struct {
 }
 
 type GCPKeyJSON struct {
-    Type  string `json:"type"`
-    ProjectId  string `json:"project_id"`
-    PrivateKeyId string `json:"private_key_id"`
-    PrivateKey string `json:"private_key"`
-    ClientEmail string `json:"client_email"`
-    ClientId  string `json:"client_id"`
-    AuthUri   string `json:"auth_uri"`
-    TokenUri   string `json:"token_uri"`
-    AuthProviderX509CertUrl  string `json:"auth_provider_x509_cert_url"`
-    ClientX509CertUrl     string `json:"client_x509_cert_url"`
+	Type                    string `json:"type"`
+	ProjectId               string `json:"project_id"`
+	PrivateKeyId            string `json:"private_key_id"`
+	PrivateKey              string `json:"private_key"`
+	ClientEmail             string `json:"client_email"`
+	ClientId                string `json:"client_id"`
+	AuthUri                 string `json:"auth_uri"`
+	TokenUri                string `json:"token_uri"`
+	AuthProviderX509CertUrl string `json:"auth_provider_x509_cert_url"`
+	ClientX509CertUrl       string `json:"client_x509_cert_url"`
 }
 
 type GCPOrgPayload struct {
-    Data struct {
-		ServiceAccountName      string          `json:"serviceAccountName"`
-		ServiceAccountKeyJson   GCPKeyJSON      `json:"serviceAccountKeyJson"`
+	Data struct {
+		ServiceAccountName    string     `json:"serviceAccountName"`
+		ServiceAccountKeyJson GCPKeyJSON `json:"serviceAccountKeyJson"`
 	} `json:"data"`
 }
 
 type GCPOrgAttributes struct {
-    ServiceAccountName string `json:"serviceAccountName"`
-    ServiceAccountUniqueId string `json:"ServiceAccountUniqueId"`
+	ServiceAccountName     string `json:"serviceAccountName"`
+	ServiceAccountUniqueId string `json:"ServiceAccountUniqueId"`
 }
 
 type GCPOrgResponse struct {
 	Data struct {
-		ID         string            `json:"id"`
+		ID         string           `json:"id"`
 		Attributes GCPOrgAttributes `json:"attributes"`
 	} `json:"data"`
 }


### PR DESCRIPTION
Adds support for all (i.e. numeric types in `values.value` field)  and for a string array in the `values` field.

Fixes #32 