### PR TITLE
Fix bug of processing Rule ExtraSettings values property

### DIFF
--- a/conformity/account_settings.go
+++ b/conformity/account_settings.go
@@ -2,10 +2,11 @@ package conformity
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/trendmicro/terraform-provider-conformity/pkg/cloudconformity"
 	"reflect"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/trendmicro/terraform-provider-conformity/pkg/cloudconformity"
 )
 
 func flattenAccountSettings(settings *cloudconformity.AccountSettings, rule []cloudconformity.GetRuleSettings) []interface{} {
@@ -118,7 +119,7 @@ func flattenExtraSettings(extra []*cloudconformity.RuleSettingExtra) []interface
 
 			values := v.Values.([]interface{})
 			switch v.Type {
-			case "regions":
+			case "regions", "ignored-regions":
 
 				e["regions"] = expandStringList(values)
 

--- a/conformity/resource_conformity_profile.go
+++ b/conformity/resource_conformity_profile.go
@@ -3,8 +3,9 @@ package conformity
 import (
 	"context"
 	"fmt"
-	"github.com/trendmicro/terraform-provider-conformity/pkg/cloudconformity"
 	"sort"
+
+	"github.com/trendmicro/terraform-provider-conformity/pkg/cloudconformity"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"


### PR DESCRIPTION
Fix the bug of flatening extraSettings item with "ignored-regions" type.

1. Just re-use the "regions" type logic
2. Will refactor it when the Conformity API support "ignored-regions" type
