### PR TITLE
Fix account settings: rule extraSettings item

### DIFF
--- a/conformity/account_settings.go
+++ b/conformity/account_settings.go
@@ -2,7 +2,6 @@ package conformity
 
 import (
 	"fmt"
-	"log"
 	"reflect"
 	"strings"
 
@@ -140,7 +139,6 @@ func flattenExtraSettings(extra []*cloudconformity.RuleSettingExtra) []interface
 		if v.Mappings != nil {
 
 			mappings := v.Mappings.([]interface{})
-			log.Printf("extra setting name /%v", v.Type)
 			e["mappings"] = flattenRuleMappings(mappings)
 		}
 
@@ -156,10 +154,6 @@ func flattenRuleValues(values []interface{}) []interface{} {
 	vs := make([]interface{}, 0, len(values))
 
 	for _, value := range values {
-
-		if reflect.TypeOf(value).String() == "string" {
-			log.Printf("[TEST] string value: %v", value)
-		}
 
 		v := make(map[string]interface{})
 		item := value.(map[string]interface{})

--- a/conformity/account_settings.go
+++ b/conformity/account_settings.go
@@ -2,6 +2,7 @@ package conformity
 
 import (
 	"fmt"
+	"log"
 	"reflect"
 	"strings"
 
@@ -127,6 +128,9 @@ func flattenExtraSettings(extra []*cloudconformity.RuleSettingExtra) []interface
 
 				e["multiple_object_values"] = flattenRuleMultipleObject(values[0].(map[string]interface{}))
 
+			case "tags":
+				e["tags"] = expandStringList(values)
+
 			default:
 
 				e["values"] = flattenRuleValues(values)
@@ -136,6 +140,7 @@ func flattenExtraSettings(extra []*cloudconformity.RuleSettingExtra) []interface
 		if v.Mappings != nil {
 
 			mappings := v.Mappings.([]interface{})
+			log.Printf("extra setting name /%v", v.Type)
 			e["mappings"] = flattenRuleMappings(mappings)
 		}
 
@@ -151,6 +156,10 @@ func flattenRuleValues(values []interface{}) []interface{} {
 	vs := make([]interface{}, 0, len(values))
 
 	for _, value := range values {
+
+		if reflect.TypeOf(value).String() == "string" {
+			log.Printf("[TEST] string value: %v", value)
+		}
 
 		v := make(map[string]interface{})
 		item := value.(map[string]interface{})
@@ -398,7 +407,6 @@ func processRuleExtraSettings(es []interface{}) []cloudconformity.RuleSettingExt
 		switch extraSetting[i].Type {
 
 		case "single-string-value", "single-number-value", "ttl", "single-value-regex":
-
 			extraSetting[i].Value = item["value"].(string)
 
 		case "regions":
@@ -406,6 +414,14 @@ func processRuleExtraSettings(es []interface{}) []cloudconformity.RuleSettingExt
 			extraSetting[i].Values = expandStringList(item["regions"].(*schema.Set).List())
 			regions := true
 			extraSetting[i].Regions = &regions
+
+		case "ignored-regions":
+
+			extraSetting[i].Values = expandStringList(item["regions"].(*schema.Set).List())
+
+		case "tags":
+
+			extraSetting[i].Values = expandStringList(item["tags"].(*schema.Set).List())
 
 		case "multiple-object-values":
 

--- a/conformity/rule_settings_schema.go
+++ b/conformity/rule_settings_schema.go
@@ -56,7 +56,7 @@ func ExtraSettingSchema() *schema.Schema {
 					Required: true,
 					ValidateFunc: validation.StringInSlice([]string{"multiple-string-values", "multiple-number-values", "multiple-aws-account-values",
 						"choice-multiple-value", "choice-single-value", "single-number-value", "single-string-value", "ttl", "single-value-regex", "tags",
-						"countries", "multiple-ip-values", "regions", "multiple-object-values", "multiple-vpc-gateway-mappings"}, true),
+						"countries", "multiple-ip-values", "regions", "ignored-regions", "multiple-object-values", "multiple-vpc-gateway-mappings"}, true),
 				},
 				"value": {
 					Type:     schema.TypeString,
@@ -69,6 +69,13 @@ func ExtraSettingSchema() *schema.Schema {
 						Type: schema.TypeString,
 						// add validation here
 						// region should follow the correct syntax
+					},
+				},
+				"tags": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
 					},
 				},
 				"multiple_object_values": {

--- a/docs/resources/conformity_aws_account.md
+++ b/docs/resources/conformity_aws_account.md
@@ -142,6 +142,42 @@ resource "conformity_aws_account" "aws" {
                 }
             }
         }
+        // implement ignored-regions
+        rule {
+            rule_id = "Config-001"
+            settings {
+                enabled     = true
+                risk_level  = "HIGH"
+
+                extra_settings {
+                    name = "ignoredRegions"
+                    regions = [
+                        "ap-southeast-2",
+                        "us-west-2",
+                        "us-east-2"
+                    ]
+                    type = "ignored-regions"
+                }
+            }
+        }
+        // implement tags
+        rule {
+            rule_id = "CWE-002"
+            settings {
+                enabled     = true
+                risk_level  = "HIGH"
+
+                extra_settings {
+                    name = "accountTags"
+                    tags = [
+                        "Ta1",
+                        "Ta2",
+                        "Ta3"
+                    ]
+                    type = "tags"
+                }
+            }
+        }
     }
 }
 ```

--- a/example/aws/account.tf
+++ b/example/aws/account.tf
@@ -1,143 +1,179 @@
 resource "conformity_aws_account" "aws" {
-    name        = "aws-conformity"
-    environment = "development"
-    role_arn    = "${aws_cloudformation_stack.cloud-conformity.outputs["CloudConformityRoleArn"]}"
-    external_id = data.conformity_external_id.external.external_id
-    tags = ["development"]
-    
-    settings {
-          rule {
-              rule_id = "S3-021"
+  name        = "aws-conformity"
+  environment = "development"
+  role_arn    = aws_cloudformation_stack.cloud-conformity.outputs["CloudConformityRoleArn"]
+  external_id = data.conformity_external_id.external.external_id
+  tags        = ["development"]
 
-              settings {
-                  enabled     = false
-                  risk_level  = "HIGH"
-                  rule_exists = false
-                }
-            }
-        // implement value
-        rule {
-            rule_id = "RDS-018"
-            settings {
-                enabled     = true
-                risk_level  = "MEDIUM"
-                rule_exists = false
-                exceptions {
-                    tags        = [
-                        "mysql-backups",
-                    ]
-                }
-                extra_settings {
-                    name    = "threshold"
-                    type    = "single-number-value"
-                    value   = "90"
-                }
-            }
-        }
-        // implement multiple values
-        rule {
-            rule_id = "SNS-002"
-            settings {
-                enabled     = true
-                risk_level  = "MEDIUM"
-                rule_exists = false
-                exceptions {
-                    tags        = [
-                        "some_tag",
-                    ]
-                }
-                extra_settings {
-                    name    = "conformityOrganization"
-                    type    = "choice-multiple-value"
-                    values {
-                        enabled = false
-                        label   = "All within this Conformity organization"
-                        value   = "includeConformityOrganization"
-                    }
-                    values {
-                        enabled = true
-                        label   = "All within this AWS Organization"
-                        value   = "includeAwsOrganizationAccounts"
-                    }
-                }
-            }
-        }
-        // implement regions
-        rule {
-            rule_id = "RTM-008"
-            settings {
-                enabled     = true
-                risk_level  = "MEDIUM"
-                rule_exists = false
-                extra_settings {
-                    name    = "authorisedRegions"
-                    regions = [
-                        "ap-southeast-2",
-                        "eu-west-1",
-                        "us-east-1",
-                        "us-west-2",
-                    ]
-                    type    = "regions"
-                }
-            }
-        }
-        // implement multiple_object_values
-        rule {
-            rule_id = "RTM-011"
-            settings {
-                enabled     = true
-                risk_level  = "MEDIUM"
-                rule_exists = false
-                extra_settings {
-                    name    = "patterns"
-                    type    = "multiple-object-values"
-                    multiple_object_values {
-                        event_name         = "^(iam.amazonaws.com)"
-                        event_source       = "^(IAM).*"
-                        user_identity_type = "^(Delete).*"
-                    }
-                }
-            }
-        }
-        // implement mappings
-        rule {
-            rule_id = "VPC-013"
-            settings {
-                enabled     = true
-                risk_level  = "LOW"
-                rule_exists = false
-                extra_settings {
-                    name    = "SpecificVPCToSpecificGatewayMapping"
-                    type    = "multiple-vpc-gateway-mappings"
-                    // can be multiple mappings
-                    mappings {
-                        // can be multilple value
-                        // if mappings is declared, values is required
-                        values {
-                            // name is required
-                            // type is required
-                            name = "gatewayIds"
-                            type = "multiple-string-values"
-                            // can be one of this value/values
-                            values {
-                                // value is required
-                                // validation value should start with nat-
-                                value = "nat-001"
-                            }
-                            values {
-                                value = "nat-002"
-                            }
-                        }
-                        values {
-                            name  = "vpcId"
-                            type  = "single-string-value"
-                             // can be one of this value/values
-                             // validation value should start with vpc-
-                            value = "vpc-001"
-                        }
-                    }
-                }
-            }
-        }
+  settings {
+    rule {
+      rule_id = "S3-021"
+
+      settings {
+        enabled     = false
+        risk_level  = "HIGH"
+        rule_exists = false
+      }
     }
+    // implement value
+    rule {
+      rule_id = "RDS-018"
+      settings {
+        enabled     = true
+        risk_level  = "MEDIUM"
+        rule_exists = false
+        exceptions {
+          tags = [
+            "mysql-backups",
+          ]
+        }
+        extra_settings {
+          name  = "threshold"
+          type  = "single-number-value"
+          value = "90"
+        }
+      }
+    }
+    // implement multiple values
+    rule {
+      rule_id = "SNS-002"
+      settings {
+        enabled     = true
+        risk_level  = "MEDIUM"
+        rule_exists = false
+        exceptions {
+          tags = [
+            "some_tag",
+          ]
+        }
+        extra_settings {
+          name = "conformityOrganization"
+          type = "choice-multiple-value"
+          values {
+            enabled = false
+            label   = "All within this Conformity organization"
+            value   = "includeConformityOrganization"
+          }
+          values {
+            enabled = true
+            label   = "All within this AWS Organization"
+            value   = "includeAwsOrganizationAccounts"
+          }
+        }
+      }
+    }
+    // implement regions
+    rule {
+      rule_id = "RTM-008"
+      settings {
+        enabled     = true
+        risk_level  = "MEDIUM"
+        rule_exists = false
+        extra_settings {
+          name = "authorisedRegions"
+          regions = [
+            "ap-southeast-2",
+            "eu-west-1",
+            "us-east-1",
+            "us-west-2",
+          ]
+          type = "regions"
+        }
+      }
+    }
+    // implement multiple_object_values
+    rule {
+      rule_id = "RTM-011"
+      settings {
+        enabled     = true
+        risk_level  = "MEDIUM"
+        rule_exists = false
+        extra_settings {
+          name = "patterns"
+          type = "multiple-object-values"
+          multiple_object_values {
+            event_name         = "^(iam.amazonaws.com)"
+            event_source       = "^(IAM).*"
+            user_identity_type = "^(Delete).*"
+          }
+        }
+      }
+    }
+    // implement mappings
+    rule {
+      rule_id = "VPC-013"
+      settings {
+        enabled     = true
+        risk_level  = "LOW"
+        rule_exists = false
+        extra_settings {
+          name = "SpecificVPCToSpecificGatewayMapping"
+          type = "multiple-vpc-gateway-mappings"
+          // can be multiple mappings
+          mappings {
+            // can be multilple value
+            // if mappings is declared, values is required
+            values {
+              // name is required
+              // type is required
+              name = "gatewayIds"
+              type = "multiple-string-values"
+              // can be one of this value/values
+              values {
+                // value is required
+                // validation value should start with nat-
+                value = "nat-001"
+              }
+              values {
+                value = "nat-002"
+              }
+            }
+            values {
+              name = "vpcId"
+              type = "single-string-value"
+              // can be one of this value/values
+              // validation value should start with vpc-
+              value = "vpc-001"
+            }
+          }
+        }
+      }
+    }
+    // implement ignored-regions
+    rule {
+      rule_id = "Config-001"
+      settings {
+        enabled     = true
+        risk_level  = "HIGH"
+
+        extra_settings {
+          name = "ignoredRegions"
+          regions = [
+            "ap-southeast-2",
+            "us-west-2",
+            "us-east-2"
+          ]
+          type = "ignored-regions"
+        }
+      }
+    }
+    // implement tags
+    rule {
+      rule_id = "CWE-002"
+      settings {
+        enabled     = true
+        risk_level  = "HIGH"
+
+        extra_settings {
+          name = "accountTags"
+          tags = [
+            "Ta1",
+            "Ta2",
+            "Ta3"
+          ]
+          type = "tags"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
- Fixed the bug: got exception when syncing the rule extraSettings from Conformity
- Make `tags` item available to set
- Make `ignored-regions` item available to set
- Update the example for aws: add the sample code for these 2 item types
- Update the doc