### PR TITLE
fix: TS-747 Terraform conformity provider doc typo

### DIFF
--- a/docs/resources/conformity_communication_settings.md
+++ b/docs/resources/conformity_communication_settings.md
@@ -24,7 +24,7 @@ resource "conformity_communication_setting" "email_setting" {
         categories  = [
         "security",
         ]
-        comp 7liances = [
+        compliances = [
         "FEDRAMP",
         ]
         filter_tags = [


### PR DESCRIPTION
**Issue Link:**

- [TS-747](https://c1conformity.atlassian.net/browse/TS-747)

**What does it do?**

-  Updates typo in doc