### PR TITLE
New available configuration item to Conformity Communication Settings

### DIFF
--- a/conformity/provider_test.go
+++ b/conformity/provider_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/trendmicro/terraform-provider-conformity/pkg/cloudconformity"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/trendmicro/terraform-provider-conformity/pkg/cloudconformity"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/conformity/resource_conformity_communication_setting.go
+++ b/conformity/resource_conformity_communication_setting.go
@@ -3,10 +3,11 @@ package conformity
 import (
 	"context"
 	"fmt"
-	"github.com/trendmicro/terraform-provider-conformity/pkg/cloudconformity"
 	"log"
 	"regexp"
 	"strings"
+
+	"github.com/trendmicro/terraform-provider-conformity/pkg/cloudconformity"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -221,6 +222,14 @@ func resourceConformityCommSetting() *schema.Resource {
 								Type: schema.TypeString,
 								ValidateFunc: validation.StringInSlice([]string{"AWAF", "CISAWSF", "CISAZUREF", "CISAWSTTW", "PCI", "HIPAA", "GDPR", "APRA",
 									"NIST4", "SOC2", "NIST-CSF", "ISO27001", "AGISM", "ASAE-3150", "MAS", "FEDRAMP"}, true),
+							},
+						},
+						"statuses": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{"SUCCESS", "FAILURE"}, true),
 							},
 						},
 						"filter_tags": {
@@ -475,6 +484,7 @@ func proccessInputCommSettingFilter(payload *cloudconformity.CommunicationSettin
 
 		filter.Categories = expandStringList(f["categories"].(*schema.Set).List())
 		filter.Compliances = expandStringList(f["compliances"].(*schema.Set).List())
+		filter.Statuses = expandStringList(f["statuses"].(*schema.Set).List())
 		filter.FilterTags = expandStringList(f["filter_tags"].(*schema.Set).List())
 		filter.Regions = expandStringList(f["regions"].(*schema.Set).List())
 		filter.RiskLevels = expandStringList(f["risk_levels"].(*schema.Set).List())

--- a/docs/guides/communication_setting/communication_setting_create.md
+++ b/docs/guides/communication_setting/communication_setting_create.md
@@ -223,6 +223,10 @@ resource "conformity_communication_setting" "comm_setting" {
     compliances = []
 
     // optional | type: array of string
+    // (only used for SNS and webhook channels) An array of statuses strings from the following: "SUCCESS" | "FAILURE"
+    statuses = []
+
+    // optional | type: array of string
     filter_tags = []
 
 

--- a/example/communication_setting/sns/main.tf
+++ b/example/communication_setting/sns/main.tf
@@ -12,6 +12,7 @@ resource "conformity_communication_setting" "sns_setting" {
         compliances = [
         "FEDRAMP",
         ]
+        statuses = ["SUCCESS"]
         filter_tags = [
         "tagKey",
         ]

--- a/example/communication_setting/template.tf
+++ b/example/communication_setting/template.tf
@@ -185,6 +185,10 @@ resource "conformity_communication_setting" "comm_setting" {
     compliances = []
 
     // optional | type: array of string
+    // (only used for SNS and webhook channels) An array of statuses strings from the following: SUCCESS | FAILURE
+    statuses = []
+
+    // optional | type: array of string
     filter_tags = []
 
 

--- a/pkg/cloudconformity/create_communication_setting_test.go
+++ b/pkg/cloudconformity/create_communication_setting_test.go
@@ -18,6 +18,9 @@ func TestCreateCommunicationSettingSuccess(t *testing.T) {
 	// check the results
 	assert.Nil(t, err)
 	assert.Equal(t, response.Data[0].Attributes.Configuration.ChannelName, expectedChannelName)
+
+	assert.Equal(t, response.Data[1].Attributes.Configuration.ChannelName, "testSNSChannel")
+	assert.Equal(t, response.Data[1].Attributes.Filter.Statuses[0], "SUCCESS")
 }
 
 func TestCreateCommunicationSettingFail(t *testing.T) {
@@ -53,6 +56,40 @@ var testCreateCommunicationSettingSuccessResponse = `
           "users": [
               "t-UoU9CsK"
           ]
+        }
+      },
+      "type": "settings",
+      "relationships": {
+        "account": {
+          "data": {
+            "type": "accounts",
+            "id": "H19NxM15-"
+          }
+        },
+        "organisation": {
+          "data": {
+            "type": "organisations",
+            "id": "ryqMcJn4b"
+          }
+        }
+      }
+    },
+	{
+      "id": "communication:sns-3JD1mAub8",
+      "attributes": {
+        "type": "communication",
+        "channel": "sns",
+        "enabled": true,
+        "filter": {
+          "regions": ["us-east-1"],
+          "services": [
+            "EC2"
+          ],
+          "statuses": ["SUCCESS"]
+        },
+        "configuration": {
+          "channel_name": "testSNSChannel",
+          "arn": "sns-t-UoU9CsK"
         }
       },
       "type": "settings",

--- a/pkg/cloudconformity/models.go
+++ b/pkg/cloudconformity/models.go
@@ -382,6 +382,7 @@ type CommunicationConfiguration struct {
 type CommunicationFilter struct {
 	Categories  []string `json:"categories,omitempty"`
 	Compliances []string `json:"compliances,omitempty"`
+	Statuses    []string `json:"statuses,omitempty"`
 	FilterTags  []string `json:"filterTags,omitempty"`
 	Regions     []string `json:"regions,omitempty"`
 	RiskLevels  []string `json:"riskLevels,omitempty"`


### PR DESCRIPTION
New available configuration item to Conformity Communication Settings:

- Support the `statuses` children property of the `filter` property which can fit the [API reference](https://cloudone.trendmicro.com/docs/conformity/api-reference/tag/Settings#paths/~1settings~1communication/post)
- Update related example code and docs