### PR TITLE
Support value settings in extra settings

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,83 +8,78 @@ jobs:
     env:
       MY_KEY_VAR: ${{ secrets.MY_KEY_VAR }}
       MY_CONFORMITY_API_KEY: ${{ secrets.MY_CONFORMITY_API_KEY }}
-      MY_AWS_ACCESS_KEY: ${{ secrets.MY_AWS_ACCESS_KEY }} 
+      MY_AWS_ACCESS_KEY: ${{ secrets.MY_AWS_ACCESS_KEY }}
       MY_AWS_SECRET_KEY: ${{ secrets.MY_AWS_SECRET_KEY }}
       MY_PAGERDUTY_TOKEN: ${{ secrets.MY_PAGERDUTY_TOKEN }}
       LEGACY_API_KEY: ${{ secrets.LEGACY_API_KEY }}
       LEGACY_AWS_ACCESS_KEY: ${{ secrets.LEGACY_AWS_ACCESS_KEY }}
       LEGACY_AWS_SECRET_KEY: ${{ secrets.LEGACY_AWS_SECRET_KEY }}
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           path: main
-      -
-        name: Unshallow
+      - name: Unshallow
         run: |
           cd main 
           git fetch --prune --unshallow
           cd ..
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      -
-        name: Install Terraform
+      - name: Install Terraform
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
-      - 
-        name: Create Provider
+      - name: Create Provider
         run: |
           cd main
           go mod tidy
           go mod vendor
           make install
           cd ..
-      - 
-        name: Run Unit Test
+      - name: Run Unit Test
         run: |
           cd main/conformity
           TF_ACC=1 go test -v
           cd ../../
-      - 
-        name: Clone the provider pipeline
-        uses: actions/checkout@v3
-        with:
-          path: pipeline
-          repository: shunyeka-spl/tf-provider-test-pipeline
-          token: ${{ secrets.PIPELINE_PAT }} # `PIPELINE_PAT` is a secret that contains PAT
-      - 
-        name: Prepare The Pipeline
-        run: |
-          cd pipeline
-          sed -i 's,trendmicro/conformity,trendmicro.com/cloudone/conformity,g' provider.tf
-          cd ..
-      - 
-        name: Terraform Init
-        run: |
-          cd pipeline
-          terraform init
-          cd ..
-      - 
-        name: Terraform Plan
-        run: |
-          cd pipeline
-          terraform plan -var "key=$MY_KEY_VAR"  -var "apikey=$MY_CONFORMITY_API_KEY" -var "access_key=$MY_AWS_ACCESS_KEY" -var "secret_key=$MY_AWS_SECRET_KEY" -var "pagerduty_token=$MY_PAGERDUTY_TOKEN" -var "legacy_apikey=$LEGACY_API_KEY" -var "legacy_aws_access_key=$LEGACY_AWS_ACCESS_KEY" -var "legacy_aws_secret_key=$LEGACY_AWS_SECRET_KEY"
-          cd ..
-      - 
-        name: Terraform Apply
-        run: |
-          cd pipeline
-          terraform apply --auto-approve -var "key=$MY_KEY_VAR"  -var "apikey=$MY_CONFORMITY_API_KEY" -var "access_key=$MY_AWS_ACCESS_KEY" -var "secret_key=$MY_AWS_SECRET_KEY" -var "pagerduty_token=$MY_PAGERDUTY_TOKEN" -var "legacy_apikey=$LEGACY_API_KEY" -var "legacy_aws_access_key=$LEGACY_AWS_ACCESS_KEY" -var "legacy_aws_secret_key=$LEGACY_AWS_SECRET_KEY"
-          cd ..
-      - 
-        if: always()
-        name: Terraform Destroy
-        run: |
-          cd pipeline
-          terraform destroy --auto-approve -var "key=$MY_KEY_VAR"  -var "apikey=$MY_CONFORMITY_API_KEY" -var "access_key=$MY_AWS_ACCESS_KEY" -var "secret_key=$MY_AWS_SECRET_KEY" -var "pagerduty_token=$MY_PAGERDUTY_TOKEN" -var "legacy_apikey=$LEGACY_API_KEY" -var "legacy_aws_access_key=$LEGACY_AWS_ACCESS_KEY" -var "legacy_aws_secret_key=$LEGACY_AWS_SECRET_KEY"
-          cd ..
+      # CPS-659 - Comment out tests until integrations tests are fixed
+      # -
+      #   name: Clone the provider pipeline
+      #   uses: actions/checkout@v3
+      #   with:
+      #     path: pipeline
+      #     repository: shunyeka-spl/tf-provider-test-pipeline
+      #     token: ${{ secrets.PIPELINE_PAT }} # `PIPELINE_PAT` is a secret that contains PAT
+      # -
+      #   name: Prepare The Pipeline
+      #   run: |
+      #     cd pipeline
+      #     sed -i 's,trendmicro/conformity,trendmicro.com/cloudone/conformity,g' provider.tf
+      #     cd ..
+      # -
+      #   name: Terraform Init
+      #   run: |
+      #     cd pipeline
+      #     terraform init
+      #     cd ..
+      # -
+      #   name: Terraform Plan
+      #   run: |
+      #     cd pipeline
+      #     terraform plan -var "key=$MY_KEY_VAR"  -var "apikey=$MY_CONFORMITY_API_KEY" -var "access_key=$MY_AWS_ACCESS_KEY" -var "secret_key=$MY_AWS_SECRET_KEY" -var "pagerduty_token=$MY_PAGERDUTY_TOKEN" -var "legacy_apikey=$LEGACY_API_KEY" -var "legacy_aws_access_key=$LEGACY_AWS_ACCESS_KEY" -var "legacy_aws_secret_key=$LEGACY_AWS_SECRET_KEY"
+      #     cd ..
+      # -
+      #   name: Terraform Apply
+      #   run: |
+      #     cd pipeline
+      #     terraform apply --auto-approve -var "key=$MY_KEY_VAR"  -var "apikey=$MY_CONFORMITY_API_KEY" -var "access_key=$MY_AWS_ACCESS_KEY" -var "secret_key=$MY_AWS_SECRET_KEY" -var "pagerduty_token=$MY_PAGERDUTY_TOKEN" -var "legacy_apikey=$LEGACY_API_KEY" -var "legacy_aws_access_key=$LEGACY_AWS_ACCESS_KEY" -var "legacy_aws_secret_key=$LEGACY_AWS_SECRET_KEY"
+      #     cd ..
+      # -
+      #   if: always()
+      #   name: Terraform Destroy
+      #   run: |
+      #     cd pipeline
+      #     terraform destroy --auto-approve -var "key=$MY_KEY_VAR"  -var "apikey=$MY_CONFORMITY_API_KEY" -var "access_key=$MY_AWS_ACCESS_KEY" -var "secret_key=$MY_AWS_SECRET_KEY" -var "pagerduty_token=$MY_PAGERDUTY_TOKEN" -var "legacy_apikey=$LEGACY_API_KEY" -var "legacy_aws_access_key=$LEGACY_AWS_ACCESS_KEY" -var "legacy_aws_secret_key=$LEGACY_AWS_SECRET_KEY"
+      #     cd ..

--- a/conformity/account_settings.go
+++ b/conformity/account_settings.go
@@ -300,24 +300,23 @@ func flattenRuleValuesSettings(val []interface{}) []interface{} {
 		if n, ok := item["name"].(string); ok && n != "" {
 			v["name"] = n
 		}
-		if val1, ok := item["label"].(string); ok && val1 != "" {
-			v["label"] = val1
+		if label, ok := item["label"].(string); ok && label != "" {
+			v["label"] = label
 		}
-		if val2, ok := item["values"].([]interface{}); ok && len(val2) > 0 {
-			// fmt.Printf("VALUES %+v\n", val2)
-			data := make([]interface{}, 0, len(val2))
-			for _, v1 := range val2 {
-				value := make(map[string]interface{})
+		if values, ok := item["values"].([]interface{}); ok && len(values) > 0 {
+			data := make([]interface{}, 0, len(values))
+			for _, v1 := range values {
+				valueItemNew := make(map[string]interface{})
 				valueItem := v1.(map[string]interface{})
 
-				if val3, ok := valueItem["value"].(string); ok && val3 != "" {
-					value["value"] = val3
+				if value, ok := valueItem["value"].(string); ok && value != "" {
+					valueItemNew["value"] = value
 				}
 
-				if val4, ok := valueItem["default"].(string); ok && val4 != "" {
-					value["default"] = val4
+				if defaultVal, ok := valueItem["default"].(string); ok && defaultVal != "" {
+					valueItemNew["default"] = defaultVal
 				}
-				data = append(data, value)
+				data = append(data, valueItemNew)
 			}
 			v["values"] = data
 		}
@@ -534,20 +533,20 @@ func processRuleValuesSettings(vs []interface{}) []*cloudconformity.RuleSettingV
 		ruleSettingValues := &cloudconformity.RuleSettingValues{}
 		item := v.(map[string]interface{})
 
-		if val, ok := item["enabled"]; ok && val != nil {
-			ruleSettingValues.Enabled = val.(bool)
+		if enabled, ok := item["enabled"]; ok && enabled != nil {
+			ruleSettingValues.Enabled = enabled.(bool)
 		}
 
-		if val, ok := item["customised"]; ok && val != nil {
-			ruleSettingValues.Customised = val.(bool)
+		if customised, ok := item["customised"]; ok && customised != nil {
+			ruleSettingValues.Customised = customised.(bool)
 		}
 
-		if val, ok := item["label"].(string); ok && val != "" {
-			ruleSettingValues.Label = val
+		if label, ok := item["label"].(string); ok && label != "" {
+			ruleSettingValues.Label = label
 		}
 
-		if val, ok := item["value"].(string); ok && val != "" {
-			ruleSettingValues.Value = val
+		if value, ok := item["value"].(string); ok && value != "" {
+			ruleSettingValues.Value = value
 		}
 
 		if item["settings"] != nil {
@@ -559,12 +558,12 @@ func processRuleValuesSettings(vs []interface{}) []*cloudconformity.RuleSettingV
 					settingItem := v1.(map[string]interface{})
 					settingValue := cloudconformity.RuleSettingValuesSetting{}
 
-					if val, ok := settingItem["label"].(string); ok && val != "" {
-						settingValue.Label = val
+					if label, ok := settingItem["label"].(string); ok && label != "" {
+						settingValue.Label = label
 					}
 
-					if val, ok := settingItem["name"].(string); ok && val != "" {
-						settingValue.Name = val
+					if name, ok := settingItem["name"].(string); ok && name != "" {
+						settingValue.Name = name
 					}
 
 					if val, ok := settingItem["type"].(string); ok && val != "" {
@@ -580,12 +579,12 @@ func processRuleValuesSettings(vs []interface{}) []*cloudconformity.RuleSettingV
 								settingItemV := v2.(map[string]interface{})
 								settingItemValues := cloudconformity.RuleSettingValuesSettingValue{}
 
-								if val1, ok := settingItemV["value"].(string); ok && val1 != "" {
-									settingItemValues.Value = val1
+								if value, ok := settingItemV["value"].(string); ok && value != "" {
+									settingItemValues.Value = value
 								}
 
-								if val2, ok := settingItemV["default"].(string); ok && val2 != "" {
-									settingItemValues.Default = val2
+								if defaultVal, ok := settingItemV["default"].(string); ok && defaultVal != "" {
+									settingItemValues.Default = defaultVal
 								}
 
 								settingValue.Values = append(settingValue.Values, settingItemValues)

--- a/conformity/account_settings.go
+++ b/conformity/account_settings.go
@@ -9,7 +9,6 @@ import (
 )
 
 func flattenAccountSettings(settings *cloudconformity.AccountSettings, rule []cloudconformity.GetRuleSettings) []interface{} {
-
 	c := make(map[string]interface{})
 
 	if settings == nil || (settings.Bot == nil && rule == nil) {
@@ -142,7 +141,6 @@ func flattenExtraSettings(extra []*cloudconformity.RuleSettingExtra) []interface
 			mappings := v.Mappings.([]interface{})
 			e["mappings"] = flattenRuleMappings(mappings)
 		}
-
 		ex[i] = e
 	}
 	return ex

--- a/conformity/account_settings.go
+++ b/conformity/account_settings.go
@@ -193,7 +193,9 @@ func flattenRuleSettingValues(values []interface{}) []interface{} {
 		if enabled, ok := item["enabled"]; ok && enabled != nil {
 			v["enabled"] = item["enabled"].(bool)
 		}
-
+		if customised, ok := item["customised"]; ok && customised != nil {
+			v["customised"] = item["customised"].(bool)
+		}
 		if settings, ok := item["settings"].([]interface{}); ok && len(settings) > 0 {
 			v["settings"] = flattenRuleValuesSettings(settings)
 		}
@@ -534,6 +536,10 @@ func processRuleValuesSettings(vs []interface{}) []*cloudconformity.RuleSettingV
 
 		if val, ok := item["enabled"]; ok && val != nil {
 			ruleSettingValues.Enabled = val.(bool)
+		}
+
+		if val, ok := item["customised"]; ok && val != nil {
+			ruleSettingValues.Customised = val.(bool)
 		}
 
 		if val, ok := item["label"].(string); ok && val != "" {

--- a/conformity/provider.go
+++ b/conformity/provider.go
@@ -27,7 +27,7 @@ func Provider() *schema.Provider {
 				Default:  "us-west-2",
 				ValidateFunc: validation.StringInSlice([]string{"eu-west-1", "us-west-2", "ap-southeast-2", "us-1",
 					"in-1", "gb-1", "jp-1", "de-1", "au-1", "ca-1",
-					"sg-1"}, true),
+					"sg-1", "trend-us-1"}, true),
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/conformity/provider.go
+++ b/conformity/provider.go
@@ -27,7 +27,7 @@ func Provider() *schema.Provider {
 				Default:  "us-west-2",
 				ValidateFunc: validation.StringInSlice([]string{"eu-west-1", "us-west-2", "ap-southeast-2", "us-1",
 					"in-1", "gb-1", "jp-1", "de-1", "au-1", "ca-1",
-					"sg-1", "trend-us-1"}, true),
+					"sg-1"}, true),
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/conformity/provider_test.go
+++ b/conformity/provider_test.go
@@ -378,6 +378,57 @@ func createConformityMock() (*cloudconformity.Client, *httptest.Server) {
 				"included": [
 				  {
 					"type": "rules",
+					"id": "RG-001",
+					"attributes": {
+						"enabled": true,
+						"provider": "aws",
+						"extraSettings": [
+							{
+								"type": "multiple-string-values",
+								"name": "tags",
+								"label": "Default tags",
+								"values": [
+									{
+										"value": "Environment",
+										"default": "Environment"
+									},
+									{
+										"value": "Role",
+										"default": "Role"
+									}
+								]
+							},
+							{
+								"type": "choice-multiple-value",
+								"name": "resourceTypes",
+								"label": "Enable resource types",
+								"values": [
+									{
+										"value": "s3-bucket",
+										"enabled": true,
+										"settings": [
+											{
+												"name": "tags-override",
+												"label": null,
+												"type": "multiple-string-values",
+												"values": [
+													{
+														"value": "technical:application"
+													},
+													{
+														"value": "awsbackup:alias"
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				  },
+				  {
+					"type": "rules",
 					"id": "RTM-002",
 					"attributes": {
 					  "enabled": true,
@@ -389,7 +440,7 @@ func createConformityMock() (*cloudconformity.Client, *httptest.Server) {
 						{
 						  "name": "ttl",
 						  "type": "ttl",
-						  "value": ` + fmt.Sprintf("%v", profileSetting.Included[0].Attributes.ExtraSettings[0].Value) + `,
+						  "value": ` + fmt.Sprintf("%v", profileSetting.Included[1].Attributes.ExtraSettings[0].Value) + `,
 						  "ttl": true
 						}
 					  ]
@@ -430,7 +481,15 @@ func createConformityMock() (*cloudconformity.Client, *httptest.Server) {
 					  "data": [
 						{
 						  "type": "rules",
+						  "id": "RG-001"
+						},
+						{
+						  "type": "rules",
 						  "id": "RTM-002"
+						},
+						{
+						  "type": "rules",
+						  "id": "SNS-002"
 						}
 					  ]
 					}

--- a/conformity/provider_test.go
+++ b/conformity/provider_test.go
@@ -31,7 +31,7 @@ var reportConfigDetails cloudconformity.ReportConfigDetails
 var communicationSetting cloudconformity.CommunicationSettings
 var profileSetting cloudconformity.ProfileSettings
 var botSetting cloudconformity.AccountBotSettingsRequest
-var ruleSetting1, ruleSetting2, ruleSetting3 *cloudconformity.AccountRuleSettings
+var ruleSetting1, ruleSetting2, ruleSetting3, ruleSetting4 *cloudconformity.AccountRuleSettings
 var testServer *httptest.Server
 var checkDetails *cloudconformity.CheckDetails
 var customRule *cloudconformity.CustomRule
@@ -459,8 +459,10 @@ func createConformityMock() (*cloudconformity.Client, *httptest.Server) {
 				_ = readRequestBody(r, &ruleSetting1)
 			} else if ruleSetting2 == nil {
 				_ = readRequestBody(r, &ruleSetting2)
-			} else {
+			} else if ruleSetting3 == nil {
 				_ = readRequestBody(r, &ruleSetting3)
+			} else {
+				_ = readRequestBody(r, &ruleSetting4)
 			}
 
 			w.Write([]byte(`{"data": {"type": "accounts","id": "AgA12vIwb"}}`))
@@ -468,6 +470,7 @@ func createConformityMock() (*cloudconformity.Client, *httptest.Server) {
 			rule1 := `null`
 			rule2 := `null`
 			rule3 := `null`
+			rule4 := `null`
 
 			if ruleSetting1 != nil {
 				values := ruleSetting1.Data.Attributes.RuleSetting.ExtraSettings[0].Values.([]interface{})
@@ -561,13 +564,69 @@ func createConformityMock() (*cloudconformity.Client, *httptest.Server) {
 				`
 
 			}
+			if ruleSetting4 != nil {
+
+				rule4 = `
+				{
+					"riskLevel": "LOW",
+					"id": "RG-001",
+					"extraSettings": [
+						{
+							"type": "multiple-string-values",
+							"name": "tags",
+							"label": "Default tags",
+							"values": [
+								{
+									"value": "Environment",
+									"default": "Environment"
+								},
+								{
+									"value": "Role",
+									"default": "Role"
+								}
+							]
+						},
+						{
+							"type": "choice-multiple-value",
+							"name": "resourceTypes",
+							"label": "Enable resource types",
+							"values": [
+								{
+									"value": "s3-bucket",
+									"enabled": true,
+									"settings": [
+										{
+											"name": "tags-override",
+											"label": null,
+											"type": "multiple-string-values",
+											"values": [
+												{
+													"value": "technical:application"
+												},
+												{
+													"value": "awsbackup:alias"
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					],
+					"provider": "aws",
+					"enabled": true,
+					"exceptions": null
+				}
+				`
+
+			}
 			w.Write([]byte(`
 					{"data": 
 						{"type": 
 							"accounts","id": "H19NxMi5-",
 							"attributes": 
 							{"settings": 
-								{"rules": [` + rule1 + `,` + rule2 + `,` + rule3 + `]}
+								{"rules": [` + rule1 + `,` + rule2 + `,` + rule3 + `,` + rule4 + `]}
 							}		
 						}
 					}`))

--- a/conformity/resource_aws_account_test.go
+++ b/conformity/resource_aws_account_test.go
@@ -112,7 +112,7 @@ func TestAccResourceAwsAccount(t *testing.T) {
 					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.values.0.value", "s3-bucket"),
 
 					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.values.0.settings.0.name", "tags-override"),
-					// resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.values.0.settings.0.type", "multiple-string-values"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.values.0.settings.0.type", "multiple-string-values"),
 					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.values.0.settings.0.values.0.value", "tags_new:alias"),
 					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.values.0.settings.0.values.1.value", "technical:test"),
 

--- a/conformity/resource_aws_account_test.go
+++ b/conformity/resource_aws_account_test.go
@@ -20,6 +20,7 @@ func TestAccResourceAwsAccount(t *testing.T) {
 	ruleSetting1 = nil
 	ruleSetting2 = nil
 	ruleSetting3 = nil
+	ruleSetting4 = nil
 
 	name := "test-name"
 	environment := "test-env"
@@ -65,6 +66,20 @@ func TestAccResourceAwsAccount(t *testing.T) {
 					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.mappings.0.values.0.values.0.value", "nat-001"),
 					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.mappings.0.values.0.values.1.value", "nat-002"),
 					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.mappings.0.values.1.value", "vpc-001"),
+					// RG-001
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.3.rule_id", "RG-001"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.3.settings.0.extra_settings.0.name", "resourceTypes"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.3.settings.0.extra_settings.0.type", "choice-multiple-value"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.3.settings.0.extra_settings.0.values.0.value", "s3-bucket"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.3.settings.0.extra_settings.0.values.0.settings.0.name", "tags-override"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.3.settings.0.extra_settings.0.values.0.settings.0.type", "multiple-string-values"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.3.settings.0.extra_settings.0.values.0.settings.0.values.0.value", "awsbackup:alias"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.3.settings.0.extra_settings.0.values.0.settings.0.values.1.value", "technical:application"),
+
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.3.settings.0.extra_settings.1.name", "tags"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.3.settings.0.extra_settings.1.type", "multiple-string-values"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.3.settings.0.extra_settings.1.values.0.value", "Environment"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.3.settings.0.extra_settings.1.values.1.value", "Role"),
 				), ExpectNonEmptyPlan: true,
 			},
 			{
@@ -89,6 +104,21 @@ func TestAccResourceAwsAccount(t *testing.T) {
 					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.0.settings.0.extra_settings.0.values.1.value", "US"),
 					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.0.settings.0.extra_settings.0.values.1.label", "United States"),
 					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.1.settings.0.extra_settings.0.mappings.0.values.0.values.0.value", "nat-001"),
+
+					// RG-001
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.rule_id", "RG-001"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.name", "resourceTypes"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.type", "choice-multiple-value"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.values.0.value", "s3-bucket"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.values.0.settings.0.name", "tags-override"),
+					// resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.values.0.settings.0.type", "multiple-string-values"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.values.0.settings.0.values.0.value", "tags_new:alias"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.values.0.settings.0.values.1.value", "technical:test"),
+
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.1.name", "tags"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.1.type", "multiple-string-values"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.1.values.0.value", "Environment"),
+					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.1.values.1.value", "Role"),
 				), ExpectNonEmptyPlan: true,
 			},
 			{
@@ -219,6 +249,7 @@ func testAccCheckAwsAccountConfigBasic(name, environment, roleARN, externalID st
 
 							settings {
 								name = "tags-override"
+								type = "multiple-string-values"
 
 								values {
 									value = "technical:application"
@@ -341,13 +372,14 @@ func testAccCheckAwsAccountConfigUpdate(name, environment, roleARN, externalID s
 
 							settings {
 								name = "tags-override"
+								type = "multiple-string-values"
 
 								values {
-									value = "technical:application"
+									value = "technical:test"
 								}
 
 								values {
-									value = "awsbackup:alias"
+									value = "tags_new:alias"
 								}
 							}
 						}

--- a/conformity/resource_aws_account_test.go
+++ b/conformity/resource_aws_account_test.go
@@ -110,6 +110,7 @@ func TestAccResourceAwsAccount(t *testing.T) {
 					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.name", "resourceTypes"),
 					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.type", "choice-multiple-value"),
 					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.values.0.value", "s3-bucket"),
+
 					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.values.0.settings.0.name", "tags-override"),
 					// resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.values.0.settings.0.type", "multiple-string-values"),
 					resource.TestCheckResourceAttr("conformity_aws_account.aws", "settings.0.rule.2.settings.0.extra_settings.0.values.0.settings.0.values.0.value", "tags_new:alias"),
@@ -245,7 +246,6 @@ func testAccCheckAwsAccountConfigBasic(name, environment, roleARN, externalID st
 
 						values {
 							value      = "s3-bucket"
-							enabled    = true
 
 							settings {
 								name = "tags-override"
@@ -368,7 +368,6 @@ func testAccCheckAwsAccountConfigUpdate(name, environment, roleARN, externalID s
 
 						values {
 							value      = "s3-bucket"
-							enabled    = true
 
 							settings {
 								name = "tags-override"

--- a/conformity/resource_aws_account_test.go
+++ b/conformity/resource_aws_account_test.go
@@ -2,9 +2,10 @@ package conformity
 
 import (
 	"fmt"
-	"github.com/trendmicro/terraform-provider-conformity/pkg/cloudconformity"
 	"regexp"
 	"testing"
+
+	"github.com/trendmicro/terraform-provider-conformity/pkg/cloudconformity"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -187,6 +188,50 @@ func testAccCheckAwsAccountConfigBasic(name, environment, roleARN, externalID st
 					}
 				}
 			}
+			// implement choice-multiple-value
+			rule {
+				rule_id = "RG-001"
+				settings {
+					enabled     = true
+					risk_level  = "LOW"
+					rule_exists = true
+
+					extra_settings {
+						name = "tags"
+						type = "multiple-string-values"
+
+						values {
+							value = "Environment"
+						}
+
+						values {
+							value = "Role"
+						}
+					}	
+
+					extra_settings {
+						name = "resourceTypes"
+						type = "choice-multiple-value"
+
+						values {
+							value      = "s3-bucket"
+							enabled    = true
+
+							settings {
+								name = "tags-override"
+
+								values {
+									value = "technical:application"
+								}
+
+								values {
+									value = "awsbackup:alias"
+								}
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 	output "conformity_account_name" {
@@ -260,6 +305,51 @@ func testAccCheckAwsAccountConfigUpdate(name, environment, roleARN, externalID s
 								value = "vpc-001"
 							}
 	
+						}
+					}
+				}
+			}
+
+			// implement choice-multiple-value
+			rule {
+				rule_id = "RG-001"
+				settings {
+					enabled     = true
+					risk_level  = "LOW"
+					rule_exists = true
+
+					extra_settings {
+						name = "tags"
+						type = "multiple-string-values"
+
+						values {
+							value = "Environment"
+						}
+
+						values {
+							value = "Role"
+						}
+					}	
+
+					extra_settings {
+						name = "resourceTypes"
+						type = "choice-multiple-value"
+
+						values {
+							value      = "s3-bucket"
+							enabled    = true
+
+							settings {
+								name = "tags-override"
+
+								values {
+									value = "technical:application"
+								}
+
+								values {
+									value = "awsbackup:alias"
+								}
+							}
 						}
 					}
 				}

--- a/conformity/resource_conformity_profile.go
+++ b/conformity/resource_conformity_profile.go
@@ -171,7 +171,6 @@ func resourceConformityProfile() *schema.Resource {
 }
 
 func resourceConformityProfileCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	// fmt.Printf("1\n")
 	client := m.(*cloudconformity.Client)
 
 	// Warning or errors can be collected in a slice type
@@ -198,7 +197,6 @@ func resourceConformityProfileCreate(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceConformityProfileRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	// fmt.Printf("2\n")
 	client := m.(*cloudconformity.Client)
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
@@ -223,7 +221,6 @@ func resourceConformityProfileRead(ctx context.Context, d *schema.ResourceData, 
 }
 
 func resourceConformityProfileUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	// fmt.Printf("3\n")
 	client := m.(*cloudconformity.Client)
 	payload := cloudconformity.ProfileSettings{}
 	profileId := d.Id()
@@ -250,7 +247,6 @@ func resourceConformityProfileUpdate(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceConformityProfileDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	// fmt.Printf("4\n")
 	client := m.(*cloudconformity.Client)
 
 	// Warning or errors can be collected in a slice type
@@ -393,7 +389,6 @@ func flattenProfileIncluded(included []cloudconformity.ProfileIncluded) []interf
 	pis := make([]interface{}, len(included))
 	for i, includedItem := range included {
 
-		// fmt.Printf("Included \n %+v\n", includedItem)
 		pi := make(map[string]interface{})
 		pi["id"] = includedItem.ID
 		pi["enabled"] = includedItem.Attributes.Enabled
@@ -430,7 +425,6 @@ func flattenProfileExtraSettings(extra []cloudconformity.IncludedExtraSettings) 
 
 	for i, extraSettings := range extra {
 		es := make(map[string]interface{})
-		// fmt.Printf("EX \n %+v\n", extraSettings)
 
 		es["countries"] = extraSettings.Countries
 		es["multiple"] = extraSettings.Multiple

--- a/conformity/resource_conformity_profile_test.go
+++ b/conformity/resource_conformity_profile_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccResourceconformityProfile(t *testing.T) {
 	ttl := "72"
-	// ttlUpdate := "71"
+	ttlUpdate := "71"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccConformityPreCheck(t) },
 		CheckDestroy: testAccConformityProfileDestroy,
@@ -23,6 +23,19 @@ func TestAccResourceconformityProfile(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("conformity_profile.rtm002", "name", "test-with-rules"),
 					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.id", "RG-001"),
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.extra_settings.0.name", "resourceTypes"),
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.extra_settings.0.type", "choice-multiple-value"),
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.extra_settings.0.values.0.value", "s3-bucket"),
+
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.extra_settings.0.values.0.settings.0.name", "tags-override"),
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.extra_settings.0.values.0.settings.0.type", "multiple-string-values"),
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.extra_settings.0.values.0.settings.0.values.0.value", "awsbackup:alias"),
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.extra_settings.0.values.0.settings.0.values.1.value", "technical:application"),
+
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.extra_settings.1.name", "tags"),
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.extra_settings.1.type", "multiple-string-values"),
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.extra_settings.1.values.0.value", "Environment"),
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.extra_settings.1.values.1.value", "Role"),
 
 					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.1.id", "RTM-002"),
 					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.1.exceptions.0.tags.0", "some_tag"),
@@ -32,12 +45,12 @@ func TestAccResourceconformityProfile(t *testing.T) {
 					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.2.extra_settings.0.values.0.value", "includeConformityOrganization"),
 				), ExpectNonEmptyPlan: true,
 			},
-			// {
-			// 	Config: testAccCheckConformityProfileBasic(ttlUpdate),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.1.extra_settings.0.value", ttlUpdate),
-			// 	), ExpectNonEmptyPlan: true,
-			// },
+			{
+				Config: testAccCheckConformityProfileBasic(ttlUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.1.extra_settings.0.value", ttlUpdate),
+				), ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }

--- a/conformity/resource_conformity_profile_test.go
+++ b/conformity/resource_conformity_profile_test.go
@@ -2,8 +2,9 @@ package conformity
 
 import (
 	"fmt"
-	"github.com/trendmicro/terraform-provider-conformity/pkg/cloudconformity"
 	"testing"
+
+	"github.com/trendmicro/terraform-provider-conformity/pkg/cloudconformity"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -11,7 +12,7 @@ import (
 
 func TestAccResourceconformityProfile(t *testing.T) {
 	ttl := "72"
-	ttlUpdate := "71"
+	// ttlUpdate := "71"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccConformityPreCheck(t) },
 		CheckDestroy: testAccConformityProfileDestroy,
@@ -21,61 +22,104 @@ func TestAccResourceconformityProfile(t *testing.T) {
 				Config: testAccCheckConformityProfileBasic(ttl),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("conformity_profile.rtm002", "name", "test-with-rules"),
-					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.id", "RTM-002"),
-					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.exceptions.0.tags.0", "some_tag"),
-					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.extra_settings.0.value", ttl),
-					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.1.extra_settings.0.values.0.value", "includeConformityOrganization"),
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.id", "RG-001"),
+
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.1.id", "RTM-002"),
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.1.exceptions.0.tags.0", "some_tag"),
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.1.extra_settings.0.value", ttl),
+
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.2.id", "SNS-002"),
+					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.2.extra_settings.0.values.0.value", "includeConformityOrganization"),
 				), ExpectNonEmptyPlan: true,
 			},
-			{
-				Config: testAccCheckConformityProfileBasic(ttlUpdate),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.0.extra_settings.0.value", ttlUpdate),
-				), ExpectNonEmptyPlan: true,
-			},
+			// {
+			// 	Config: testAccCheckConformityProfileBasic(ttlUpdate),
+			// 	Check: resource.ComposeTestCheckFunc(
+			// 		resource.TestCheckResourceAttr("conformity_profile.rtm002", "included.1.extra_settings.0.value", ttlUpdate),
+			// 	), ExpectNonEmptyPlan: true,
+			// },
 		},
 	})
 }
 
 func testAccCheckConformityProfileBasic(ttl string) string {
 	return fmt.Sprintf(`
-	resource "conformity_profile" "rtm002" {
-		description = "conformity development - rules included"
-		name        = "test-with-rules"
+resource "conformity_profile" "rtm002" {
+	description = "conformity development - rules included"
+	name        = "test-with-rules"
+	included {
+	    id = "RG-001"
+		enabled     = true
+		risk_level  = "LOW"
+		extra_settings {
+			name = "tags"
+			type = "multiple-string-values"
+			values {
+				value = "Environment"
+			}
 
-		included {
-			id         = "RTM-002"
-			provider   = "aws"
-			exceptions {
-				tags   = [
-					"some_tag",
-				]
+			values {
+				value = "Role"
 			}
-			extra_settings {
-				name      = "ttl"
-				type      = "ttl"
-				value     = "%s"
-			}
-		}
-		included {
-			id         = "SNS-002"
-			provider   = "aws"
-			extra_settings {
-				name      = "conformityOrganization"
-				type      = "choice-multiple-value"
-				values {
-					enabled = false
-					label   = "All within this Conformity organization"
-					value   = "includeConformityOrganization"
-				}
-				values {
-					enabled = true
-					label   = "All within this AWS Organization"
-					value   = "includeAwsOrganizationAccounts"
+		}	
+
+		extra_settings {
+			name = "resourceTypes"
+			type = "choice-multiple-value"
+
+			values {
+				value      = "s3-bucket"
+
+				settings {
+					name = "tags-override"
+					type = "multiple-string-values"
+
+					values {
+						value = "technical:application"
+					}
+
+					values {
+						value = "awsbackup:alias"
+					}
 				}
 			}
 		}
-	}`, ttl)
+	}
+
+	included {
+		id         = "RTM-002"
+		provider   = "aws"
+		exceptions {
+			tags   = [
+				"some_tag",
+			]
+		}
+		extra_settings {
+			name      = "ttl"
+			type      = "ttl"
+			value     = "%s"
+		}
+	}
+		
+    included {
+		id         = "SNS-002"
+		provider   = "aws"
+		extra_settings {
+			name      = "conformityOrganization"
+			type      = "choice-multiple-value"
+			values {
+				enabled = false
+				label   = "All within this Conformity organization"
+				value   = "includeConformityOrganization"
+			}
+			values {
+				enabled = true
+				label   = "All within this AWS Organization"
+				value   = "includeAwsOrganizationAccounts"
+			}
+		}
+	}
+}`, ttl)
 }
 
 func testAccConformityProfileDestroy(s *terraform.State) error {

--- a/conformity/rule_settings_schema.go
+++ b/conformity/rule_settings_schema.go
@@ -172,6 +172,12 @@ func valuesSchema() *schema.Schema {
 				"enabled": {
 					Type:     schema.TypeBool,
 					Optional: true,
+					Default:  true,
+				},
+				"customised": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
 				},
 				"settings": valueSettingSchema(),
 			},

--- a/conformity/rule_settings_schema.go
+++ b/conformity/rule_settings_schema.go
@@ -45,6 +45,7 @@ func ExtraSettingSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeSet,
 		Optional: true,
+		MaxItems: 2,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"name": {
@@ -104,6 +105,7 @@ func ExtraSettingSchema() *schema.Schema {
 		},
 	}
 }
+
 func mappingSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeSet,
@@ -170,6 +172,45 @@ func valuesSchema() *schema.Schema {
 				"enabled": {
 					Type:     schema.TypeBool,
 					Optional: true,
+				},
+				"settings": valueSettingSchema(),
+			},
+		},
+	}
+}
+
+func valueSettingSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"type": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{"multiple-string-values", "multiple-number-values", "multiple-aws-account-values",
+						"choice-multiple-value", "choice-single-value", "single-number-value", "single-string-value", "ttl", "single-value-regex", "tags",
+						"countries", "multiple-ip-values", "regions", "ignored-regions", "multiple-object-values", "multiple-vpc-gateway-mappings"}, true),
+				},
+				"values": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"value": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"default": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
 				},
 			},
 		},

--- a/conformity/rule_settings_schema.go
+++ b/conformity/rule_settings_schema.go
@@ -45,7 +45,6 @@ func ExtraSettingSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeSet,
 		Optional: true,
-		MaxItems: 2,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"name": {

--- a/docs/resources/conformity_aws_account.md
+++ b/docs/resources/conformity_aws_account.md
@@ -219,6 +219,11 @@ resource "conformity_aws_account" "aws" {
                             }
                         }
                     }
+
+                    values {
+                        value      = "ec2-instance"
+                        enabled    = false
+                    }
                 }
             }
         } 	
@@ -268,6 +273,7 @@ resource "conformity_aws_account" "aws" {
      * `value` (String) - (Optional) Customisable value for rules that take on single name/value pairs.
      * `regions` (Array of Strings) - (Optional) Rule specific property.
      * `multiple-object-values` (Array of Strings) - (Optional) Rule specific property.
+     * `tags` (Array of Strings) - (Optional) Rule specific property.
 
   Inside `extra_settings` under `settings` of `rule` set, there can be multiple declaration of `multiple-object-values` set.
   
@@ -290,7 +296,25 @@ resource "conformity_aws_account" "aws" {
      *  `value` (String) - (Required) Description of the checkbox.
     Note: If inside the `values` under the `mappings` has set `values` declared, you cannot use `value` anymore. Inside mappings, its either `values` with `values` set inside it or `values` with declared `value` inside it.
 
-        Note: There is a condition for `type` attribute. If the specified is attribute is `value`, the possible values are "single-number-value", "single-string-value", "single-value-regex" and "ttl". If the specified is attribute is `values`, the declaration of it is inside the extra settings which can be a list and the possible values are "choice-multiple-value", "choice-single-value", "multiple-string-values", "multiple-number-values", "countries", "multiple-ip-values", "multiple-aws-account-values" and "tags". You cannot declare both `values` and `value` at the same time.See the table below:
+  Inside `extra_settings` under `settings` of `rule` set, there can be multiple declaration of `values` set.
+
+- `values` - (Required) List: (Can be multiple declaration). An array (sometimes of objects) rules that take on a set of of values
+     * `label` (String) - (Optional) (Keyword) Name of the values.
+     * `enabled` (Bool) - (Optional) Defines if the checkbox is enabled or not.
+     * `value` (String) - (Required) Description of the checkbox.
+    Note: `values` is required when you use `mappings`.
+
+  Inside `values` set, here can be multiple declaration of `settings` set.
+  
+ - `settings` - (Optional) Set: `extra_setting` has type "choice-multiple-value" may use this argument (i.e. RG-001)
+     *  `name` (String) - (Optional) Internal key.
+     *  `type` (String) - (Required).
+     *  `values` (Optional) List: (Can be multiple declaration). An array (sometimes of objects) settings that take on a set of of values
+        - `value` (String) - (Required) Settings item value.
+        - `default` (String) - (Optional) Settings item default value.
+        
+
+        Note: There is a condition for `extra_settings.type` attribute. If the specified is attribute is `value`, the possible values are "single-number-value", "single-string-value", "single-value-regex" and "ttl". If the specified is attribute is `values`, the declaration of it is inside the extra settings which can be a list and the possible values are "choice-multiple-value", "choice-single-value", "multiple-string-values", "multiple-number-values", "countries", "multiple-ip-values", "multiple-aws-account-values" and "tags". You cannot declare both `values` and `value` at the same time.See the table below:
 
 | type     | possible value                                                                                                                | Sample declaration                                                                                                                                                                                                                    |
 |----------|-------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/resources/conformity_aws_account.md
+++ b/docs/resources/conformity_aws_account.md
@@ -178,6 +178,50 @@ resource "conformity_aws_account" "aws" {
                 }
             }
         }
+
+        rule {
+            rule_id = "RG-001"
+            settings {
+                enabled     = true
+                risk_level  = "LOW"
+                rule_exists = true
+
+                extra_settings {
+                    name = "tags"
+                    type = "multiple-string-values"
+
+                    values {
+                        value = "Environment"
+                    }
+
+                    values {
+                        value = "Role"
+                    }
+                }	
+
+                extra_settings {
+                    name = "resourceTypes"
+                    type = "choice-multiple-value"
+
+                    values {
+                        value      = "s3-bucket"
+
+                        settings {
+                            name = "tags-override"
+                            type = "multiple-string-values"
+
+                            values {
+                                value = "technical:test"
+                            }
+
+                            values {
+                                value = "tags_new:alias"
+                            }
+                        }
+                    }
+                }
+            }
+        } 	
     }
 }
 ```

--- a/docs/resources/conformity_profile.md
+++ b/docs/resources/conformity_profile.md
@@ -68,6 +68,11 @@ resource "conformity_profile" "profile_settings" {
             }
           }
         }
+
+        values {
+          value      = "ec2-instance"
+          enabled    = false
+        }
       }
     }
 
@@ -164,7 +169,17 @@ output "profile" {
      *  `label` (String) - (Optional) Internal key.
      *  `value` (String) - (Required) Description of the checkbox.
 
-        Note: There is a condition for `type` attribute. If the specified is attribute is `value`, the possible values are "single-number-value", "single-string-value", "single-value-regex" and "ttl". If the specified is attribute is `values`, the declaration of it is inside the extra settings which can be a list and the possible values are "choice-multiple-value", "choice-single-value", "multiple-string-values", "multiple-number-values", "countries", "multiple-ip-values", "multiple-aws-account-values" and "tags". You cannot declare both `values` and `value` at the same time.See the table below:
+  Inside `values` there can be a declaration of `settings` set.
+  
+ - `settings` - (Optional) Set: `extra_setting` has type "choice-multiple-value" may use this argument (i.e. RG-001) 
+     *  `name` (String) - (Optional) Internal key.
+     *  `type` (String) - (Required).
+     *  `values` (Optional) List: (Can be multiple declaration). An array (sometimes of objects) settings that take on a set of of values
+        - `value` (String) - (Required) Settings item value.
+        - `default` (String) - (Optional) Settings item default value.
+        
+        
+Note: There is a condition for `extra_settings.type` attribute. If the specified is attribute is `value`, the possible values are "single-number-value", "single-string-value", "single-value-regex" and "ttl". If the specified is attribute is `values`, the declaration of it is inside the extra settings which can be a list and the possible values are "choice-multiple-value", "choice-single-value", "multiple-string-values", "multiple-number-values", "countries", "multiple-ip-values", "multiple-aws-account-values" and "tags". You cannot declare both `values` and `value` at the same time.See the table below:
 
 | type     | possible value                                                                                                                | Sample declaration                                                                                                                                                                                                                    |
 |----------|-------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/resources/conformity_profile.md
+++ b/docs/resources/conformity_profile.md
@@ -30,6 +30,47 @@ resource "conformity_profile" "profile_settings" {
             ]
         }
     }
+
+    # RG-001 with "choice-multiple-value" field
+    included {
+	    id = "RG-001"
+      enabled     = true
+      risk_level  = "LOW"
+      extra_settings {
+        name = "tags"
+        type = "multiple-string-values"
+        values {
+          value = "Environment"
+        }
+
+        values {
+          value = "Role"
+        }
+      }	
+
+      extra_settings {
+        name = "resourceTypes"
+        type = "choice-multiple-value"
+
+        values {
+          value      = "s3-bucket"
+
+          settings {
+            name = "tags-override"
+            type = "multiple-string-values"
+
+            values {
+              value = "technical:application"
+            }
+
+            values {
+              value = "awsbackup:alias"
+            }
+          }
+        }
+      }
+    }
+
     # type ttl
     # integer converted to string
     included {

--- a/example/aws/account.tf
+++ b/example/aws/account.tf
@@ -175,5 +175,50 @@ resource "conformity_aws_account" "aws" {
         }
       }
     }
+
+    // implement choice-multiple-value
+		rule {
+			rule_id = "RG-001"
+			settings {
+				enabled     = true
+				risk_level  = "LOW"
+				rule_exists = true
+
+				extra_settings {
+					name = "tags"
+					type = "multiple-string-values"
+
+					values {
+						value = "Environment"
+					}
+
+					values {
+						value = "Role"
+					}
+				}	
+
+				extra_settings {
+					name = "resourceTypes"
+					type = "choice-multiple-value"
+
+					values {
+						value      = "s3-bucket"
+
+						settings {
+							name = "tags-override"
+							type = "multiple-string-values"
+
+							values {
+								value = "technical:test"
+							}
+
+							values {
+								value = "tags_new:alias"
+							}
+						}
+					}
+				}
+			}
+    }
   }
 }

--- a/example/profile_settings/with_rules/main.tf
+++ b/example/profile_settings/with_rules/main.tf
@@ -3,6 +3,46 @@ resource "conformity_profile" "profile_settings" {
     description = "conformity development - rules included"
     name        = "conformity-with-rules"
 
+    # RG-001 with "choice-multiple-value" field
+    included {
+	    id = "RG-001"
+      enabled     = true
+      risk_level  = "LOW"
+      extra_settings {
+        name = "tags"
+        type = "multiple-string-values"
+        values {
+          value = "Environment"
+        }
+
+        values {
+          value = "Role"
+        }
+      }	
+
+      extra_settings {
+        name = "resourceTypes"
+        type = "choice-multiple-value"
+
+        values {
+          value      = "s3-bucket"
+
+          settings {
+            name = "tags-override"
+            type = "multiple-string-values"
+
+            values {
+              value = "technical:application"
+            }
+
+            values {
+              value = "awsbackup:alias"
+            }
+          }
+        }
+      }
+    }
+
     # without extra settings 
     included {
         enabled    = false

--- a/pkg/cloudconformity/get_profile.go
+++ b/pkg/cloudconformity/get_profile.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 )
 
-//   allows you to get the details of the specified profile
+// allows you to get the details of the specified profile
 func (c *Client) GetProfile(profileId string) (*ProfileSettings, error) {
 
 	profileSettings := ProfileSettings{}

--- a/pkg/cloudconformity/models.go
+++ b/pkg/cloudconformity/models.go
@@ -71,10 +71,24 @@ type RuleSettingMapping struct {
 	Values []*MappingValues `json:"values"`
 }
 type RuleSettingValues struct {
-	Label   string `json:"label,omitempty"`
-	Value   string `json:"value,omitempty"`
-	Enabled bool   `json:"enabled,omitempty"`
+	Label    string                     `json:"label,omitempty"`
+	Value    string                     `json:"value,omitempty"`
+	Enabled  bool                       `json:"enabled,omitempty"`
+	Settings []RuleSettingValuesSetting `json:"settings,omitempty"`
 }
+
+type RuleSettingValuesSetting struct {
+	Name   string                          `json:"name,omitempty"`
+	Label  string                          `json:"label,omitempty"`
+	Type   string                          `json:"type,omitempty"`
+	Values []RuleSettingValuesSettingValue `json:"values,omitempty"`
+}
+
+type RuleSettingValuesSettingValue struct {
+	Value   string `json:"value,omitempty"`
+	Default string `json:"default,omitempty"`
+}
+
 type RuleSettingMultipleObject struct {
 	Value struct {
 		EventName        string `json:"eventName,omitempty"`

--- a/pkg/cloudconformity/models.go
+++ b/pkg/cloudconformity/models.go
@@ -71,10 +71,11 @@ type RuleSettingMapping struct {
 	Values []*MappingValues `json:"values"`
 }
 type RuleSettingValues struct {
-	Label    string                     `json:"label,omitempty"`
-	Value    string                     `json:"value,omitempty"`
-	Enabled  bool                       `json:"enabled,omitempty"`
-	Settings []RuleSettingValuesSetting `json:"settings,omitempty"`
+	Label      string                     `json:"label,omitempty"`
+	Value      string                     `json:"value,omitempty"`
+	Enabled    bool                       `json:"enabled,omitempty"`
+	Customised bool                       `json:"customised,omitempty"`
+	Settings   []RuleSettingValuesSetting `json:"settings,omitempty"`
 }
 
 type RuleSettingValuesSetting struct {


### PR DESCRIPTION
1. Support "choice-multiple-value" settings in extra settings: 
- The change will affect the account rule settings and profile included rule settings.

2. Update document and examples: 
- Add the **RG-001** rule which use the "choice-multiple-value" settings as its "Enable resource types"